### PR TITLE
Reduce hero banner height to a more common size

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
 
     <!-- Hero Section -->
     <section
-      class="hero-image min-h-screen flex items-center justify-center text-center text-white"
+      class="hero-image min-h-[60vh] flex items-center justify-center text-center text-white"
     >
       <div class="container mx-auto px-4">
         <h1 class="title-font text-4xl md:text-6xl font-bold mb-4">


### PR DESCRIPTION
## Summary
- shrink hero banner to a more typical size using a 60vh minimum height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973627a09c832e84e70db73aca5ac7