### PR TITLE
Display service icons in Our Services section

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,9 +121,11 @@
           <div
             class="service-card bg-stone-50 p-6 rounded-lg shadow-md border border-stone-200 transition duration-300"
           >
-            <div class="text-green-700 mb-4">
-              <i class="fas fa-hill-rockslide text-4xl"></i>
-            </div>
+            <img
+              src="images/mole_trapping_icon.png"
+              alt="Traditional mole trapping icon"
+              class="mx-auto mb-4 w-16 h-16 md:w-20 md:h-20 object-contain"
+            />
             <h3 class="title-font text-xl font-bold mb-3 text-green-800">
               Traditional Mole Trapping
             </h3>
@@ -137,9 +139,11 @@
           <div
             class="service-card bg-stone-50 p-6 rounded-lg shadow-md border border-stone-200 transition duration-300"
           >
-            <div class="text-green-700 mb-4">
-              <i class="fas fa-rat text-4xl"></i>
-            </div>
+            <img
+              src="images/rodent_control_icon.png"
+              alt="Rodent control icon"
+              class="mx-auto mb-4 w-16 h-16 md:w-20 md:h-20 object-contain"
+            />
             <h3 class="title-font text-xl font-bold mb-3 text-green-800">
               Rodent Control
             </h3>
@@ -153,9 +157,11 @@
           <div
             class="service-card bg-stone-50 p-6 rounded-lg shadow-md border border-stone-200 transition duration-300"
           >
-            <div class="text-green-700 mb-4">
-              <i class="fas fa-crow text-4xl"></i>
-            </div>
+            <img
+              src="images/wildlife_management_icon.png"
+              alt="Wildlife management icon"
+              class="mx-auto mb-4 w-16 h-16 md:w-20 md:h-20 object-contain"
+            />
             <h3 class="title-font text-xl font-bold mb-3 text-green-800">
               Wildlife Management
             </h3>


### PR DESCRIPTION
## Summary
- Add responsive image icons above service headings using local image assets

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689745da9f60832e83da0adbe066ca22