### PR TITLE
feat: add interactive Cheshire service map

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,25 +476,23 @@
             </div>
           </div>
 
-          <div
-            class="mt-12 map-container bg-stone-200 rounded-lg overflow-hidden"
-          >
-            <!-- Map placeholder - in a real implementation you would embed a Google Map -->
+          <div class="mt-12 rounded-lg overflow-hidden">
             <div
-              class="w-full h-full flex items-center justify-center bg-green-50"
-            >
-              <div class="text-center p-6">
-                <i
-                  class="fas fa-map-marked-alt text-5xl text-green-700 mb-4"
-                ></i>
-                <h3 class="title-font text-xl font-bold text-green-800 mb-2">
-                  Cheshire Service Area
-                </h3>
-                <p class="text-stone-700">
-                  We cover all of Cheshire and surrounding areas
-                </p>
-              </div>
-            </div>
+              id="service-map"
+              aria-label="Interactive map showing our Cheshire service area"
+            ></div>
+            <noscript>
+              <a
+                href="https://www.google.com/maps/dir/?api=1&destination=Cheshire%2C+UK"
+                target="_blank"
+                rel="noopener"
+              >
+                <img
+                  src="https://maps.googleapis.com/maps/api/staticmap?center=53.1934,-2.5215&zoom=9&size=600x300&key=YOUR_GOOGLE_MAPS_API_KEY"
+                  alt="Static map of Cheshire service area"
+                />
+              </a>
+            </noscript>
           </div>
         </div>
       </div>
@@ -1072,6 +1070,12 @@
       </div>
     </footer>
 
+    <script src="service-map.js"></script>
+    <script
+      async
+      defer
+      src="https://maps.googleapis.com/maps/api/js?key=YOUR_GOOGLE_MAPS_API_KEY&callback=initServiceMap"
+    ></script>
     <script>
       // Mobile menu toggle
       const menuBtn = document.getElementById("menu-btn");

--- a/service-map.js
+++ b/service-map.js
@@ -1,0 +1,69 @@
+function initServiceMap() {
+  const center = { lat: 53.1934, lng: -2.5215 };
+  const map = new google.maps.Map(document.getElementById("service-map"), {
+    center,
+    zoom: 9,
+    styles: [
+      { featureType: "all", stylers: [{ saturation: -60 }] },
+      { featureType: "road", elementType: "geometry", stylers: [{ lightness: 40 }] },
+      { featureType: "poi", stylers: [{ visibility: "off" }] },
+    ],
+  });
+
+  const icon = {
+    path: "M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z",
+    fillColor: "#1f6f3b",
+    fillOpacity: 1,
+    strokeColor: "#1f6f3b",
+    strokeWeight: 1,
+    anchor: new google.maps.Point(12, 24),
+    scale: 2,
+  };
+
+  new google.maps.Marker({
+    position: center,
+    map,
+    icon,
+    title: "Cheshire",
+  });
+
+  const locations = [
+    { position: { lat: 53.144, lng: -2.362 }, title: "Sandbach" },
+    { position: { lat: 53.203, lng: -2.356 }, title: "Holmes Chapel" },
+    { position: { lat: 53.28, lng: -2.7 }, title: "Surrounding Areas" },
+  ];
+
+  locations.forEach((loc) => {
+    const marker = new google.maps.Marker({
+      position: loc.position,
+      map,
+      title: loc.title,
+    });
+    const info = new google.maps.InfoWindow({
+      content: `<strong>${loc.title}</strong>`,
+    });
+    marker.addListener("click", () => info.open(map, marker));
+  });
+
+  const serviceCoords = [
+    { lat: 53.45, lng: -3.1 },
+    { lat: 53.45, lng: -2.1 },
+    { lat: 53.2, lng: -1.9 },
+    { lat: 52.9, lng: -2.2 },
+    { lat: 52.92, lng: -3.0 },
+    { lat: 53.2, lng: -3.2 },
+  ];
+
+  const serviceArea = new google.maps.Polygon({
+    paths: serviceCoords,
+    strokeColor: "#1f6f3b",
+    strokeOpacity: 0.6,
+    strokeWeight: 2,
+    fillColor: "#1f6f3b",
+    fillOpacity: 0.1,
+  });
+
+  serviceArea.setMap(map);
+}
+
+window.initServiceMap = initServiceMap;

--- a/style.css
+++ b/style.css
@@ -30,15 +30,22 @@ body {
   transform: scale(1.02);
 }
 
-.map-container {
-  height: 400px;
-  width: 100%;
-}
-
 .gallery-image {
   transition: all 0.3s ease;
 }
 
 .gallery-image:hover {
   transform: scale(1.03);
+}
+
+#service-map {
+  width: 100%;
+  height: 400px;
+  border-radius: 12px;
+}
+
+@media (max-width: 640px) {
+  #service-map {
+    height: 300px;
+  }
 }


### PR DESCRIPTION
## Summary
- embed responsive Google Map in Areas We Cover section with noscript fallback
- add service-map.js initializing map, markers, and service polygon
- style map container with responsive dimensions and include custom pin icon
- fix custom marker path to avoid absolute URL issues
- replace binary pin icon with inline SVG to resolve binary file concerns

## Testing
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689757bb3774832eb74f456bd1facaf3