### PR TITLE
Replace Google Maps API with iframe embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,6 +411,9 @@
   loading="lazy" 
   referrerpolicy="no-referrer-when-downgrade"
   class="w-full"></iframe>
+            <noscript>
+              <a href="https://www.google.com/maps/place/Kingsley,+Frodsham" target="_blank" rel="noopener">View larger map</a>
+            </noscript>
           </div>
 
           <div class="grid grid-cols-2 md:grid-cols-3 gap-4">

--- a/style.css
+++ b/style.css
@@ -38,14 +38,14 @@ body {
   transform: scale(1.03);
 }
 
-#service-map {
+iframe {
   width: 100%;
   height: 400px;
-  border-radius: 12px;
+  border: 0;
 }
 
 @media (max-width: 640px) {
-  #service-map {
+  iframe {
     height: 300px;
   }
 }


### PR DESCRIPTION
## Summary
- Replace Google Maps API script with a simple Google Maps iframe and add a `noscript` fallback link.
- Remove obsolete `#service-map` styles and add responsive iframe styling.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68977b9963b8832e9d3c3d87cd53e2ba