### PR TITLE
feat: add responsive map container

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,21 +401,19 @@
         </h2>
 
         <div class="max-w-4xl mx-auto">
-          <div class="rounded-lg overflow-hidden mb-12">
-            <iframe 
-  src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d9515.497847535037!2d-2.6802635!3d53.2870522!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487b6fd7a863cb7f%3A0x41c1fcba8f57960!2sKingsley%2C%20Frodsham!5e0!3m2!1sen!2suk!4v1723218200000!5m2!1sen!2suk" 
-  width="100%" 
-  height="400" 
-  style="border:0;" 
-  allowfullscreen="" 
-  loading="lazy" 
-  referrerpolicy="no-referrer-when-downgrade"
-  class="w-full"></iframe>
-            <noscript>
-              <a href="https://www.google.com/maps/place/Kingsley,+Frodsham" target="_blank" rel="noopener">View larger map</a>
-            </noscript>
+          <div class="map-container">
+            <iframe
+              src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d38184.22578568327!2d-2.6802635!3d53.2870522!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487b6fd7a863cb7f%3A0x41c1fcba8f57960!2sKingsley%2C%20Frodsham!5e0!3m2!1sen!2suk!4v1723218200000!5m2!1sen!2suk"
+              width="100%"
+              height="400"
+              style="border:0;"
+              allowfullscreen=""
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+            ></iframe>
           </div>
 
+          
           <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
             <div
               class="bg-stone-50 p-4 rounded-lg border border-stone-200 text-center"

--- a/style.css
+++ b/style.css
@@ -44,6 +44,11 @@ iframe {
   border: 0;
 }
 
+.map-container {
+  max-width: 100%;
+  height: auto;
+}
+
 @media (max-width: 640px) {
   iframe {
     height: 300px;


### PR DESCRIPTION
## Summary
- embed Google Maps within a dedicated container for service area section
- add `.map-container` styles for full-width, responsive iframe

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689780d432a0832eae0e642b8b464ac5