### PR TITLE
Use local image for farm setting in gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
           <!-- Image 7 -->
           <div class="gallery-image overflow-hidden rounded-lg shadow-sm">
             <img
-              src="https://images.unsplash.com/photo-1516723720902-36f42b8a6c10?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80"
+              src="Images/farm_setting.png"
               alt="Farm setting"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />


### PR DESCRIPTION
## Summary
- Use local `farm_setting.png` for the "Farm setting" image in the gallery section.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897891f5070832eae691e6d3e05944d