### PR TITLE
Disable Tiny Slider autoplay button output

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,6 +660,7 @@
         items: 1,
         slideBy: 'page',
         autoplay: true,
+        autoplayButtonOutput: false,
         controls: false,
         nav: true
       });


### PR DESCRIPTION
## Summary
- prevent Tiny Slider from rendering its autoplay control

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898832b9674832e854958f101aa26d6