### PR TITLE
Add lazy loading and image dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,9 @@
             <img
               src="Images/mole_trapping_icon.png"
               alt="Traditional mole trapping icon"
+              loading="lazy"
+              width="111"
+              height="117"
               class="mx-auto mb-4 w-16 h-16 md:w-20 md:h-20 object-contain"
             />
             <h3 class="title-font text-xl font-bold mb-3 text-green-800">
@@ -171,6 +174,9 @@
             <img
               src="Images/rodent_control_icon.png"
               alt="Rodent control icon"
+              loading="lazy"
+              width="152"
+              height="138"
               class="mx-auto mb-4 w-16 h-16 md:w-20 md:h-20 object-contain"
             />
             <h3 class="title-font text-xl font-bold mb-3 text-green-800">
@@ -189,6 +195,9 @@
             <img
               src="Images/wildlife_management_icon.png"
               alt="Wildlife management icon"
+              loading="lazy"
+              width="130"
+              height="117"
               class="mx-auto mb-4 w-16 h-16 md:w-20 md:h-20 object-contain"
             />
             <h3 class="title-font text-xl font-bold mb-3 text-green-800">
@@ -559,6 +568,9 @@
               <img
                 src="Images/expert_at_work_lawn.png"
                 alt="Ridge & Burrow expert at work lawn"
+                loading="lazy"
+                width="1536"
+                height="1024"
                 class="w-full h-auto rounded-lg"
               />
             </div>
@@ -581,6 +593,8 @@
               <img src="Images/Sarah_L.png"
                    alt="Photo of Sarah L"
                    loading="lazy"
+                   width="1024"
+                   height="1024"
                    class="testimonial-avatar mr-3">
               <div>
                 <h4 class="font-bold">Sarah L</h4>
@@ -606,6 +620,8 @@
               <img src="Images/Geoff_R.png"
                    alt="Photo of Geoff R"
                    loading="lazy"
+                   width="1024"
+                   height="1085"
                    class="testimonial-avatar mr-3">
               <div>
                 <h4 class="font-bold">Geoff R</h4>
@@ -631,6 +647,8 @@
               <img src="Images/Karen_M.png"
                    alt="Photo of Karen M"
                    loading="lazy"
+                   width="1024"
+                   height="1172"
                    class="testimonial-avatar mr-3">
               <div>
                 <h4 class="font-bold">Karen M</h4>
@@ -656,6 +674,8 @@
               <img src="Images/Pete_H.png"
                    alt="Photo of Pete H"
                    loading="lazy"
+                   width="1024"
+                   height="1083"
                    class="testimonial-avatar mr-3">
               <div>
                 <h4 class="font-bold">Pete H</h4>
@@ -796,6 +816,9 @@
             <img
               src="Images/Molehills_in_a_field.png"
               alt="Molehills in a field"
+              loading="lazy"
+              width="1536"
+              height="1024"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />
           </div>
@@ -805,6 +828,9 @@
             <img
               src="Images/trap_placement_demonstration.png"
               alt="Trap placement demonstration"
+              loading="lazy"
+              width="1300"
+              height="846"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />
           </div>
@@ -814,6 +840,9 @@
             <img
               src="Images/expert_at_work.png"
               alt="Expert at work"
+              loading="lazy"
+              width="1536"
+              height="1024"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />
           </div>
@@ -823,6 +852,9 @@
             <img
               src="Images/restored_lawn.png"
               alt="Restored lawn"
+              loading="lazy"
+              width="1536"
+              height="1024"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />
           </div>
@@ -832,6 +864,9 @@
             <img
               src="https://images.unsplash.com/photo-1500382017468-9049fed747ef?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80"
               alt="Countryside landscape"
+              loading="lazy"
+              width="1470"
+              height="980"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />
           </div>
@@ -841,6 +876,9 @@
             <img
               src="Images/professional_tools.png"
               alt="Professional tools"
+              loading="lazy"
+              width="1536"
+              height="1024"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />
           </div>
@@ -850,6 +888,9 @@
             <img
               src="Images/farm_setting.png"
               alt="Farm setting"
+              loading="lazy"
+              width="1536"
+              height="1024"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />
           </div>
@@ -859,6 +900,9 @@
             <img
               src="https://images.unsplash.com/photo-1583845110448-8a8d7b1a0e9b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80"
               alt="Before and after"
+              loading="lazy"
+              width="1470"
+              height="980"
               class="w-full h-48 object-cover hover:opacity-90 transition"
             />
           </div>

--- a/style.css
+++ b/style.css
@@ -36,6 +36,10 @@ body {
   transform: scale(1.03);
 }
 
+.gallery-image img {
+  aspect-ratio: 3 / 2;
+}
+
 iframe {
   width: 100%;
   height: 400px;


### PR DESCRIPTION
## Summary
- add `loading="lazy"` plus width and height to service, testimonial, about, and gallery images
- use CSS `aspect-ratio` for gallery images to keep layout stable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993095ba54832ea84c0ac6b49af868