### PR TITLE
Add ARIA toggle attributes for mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,13 @@
           >
         </div>
         <div class="md:hidden">
-          <button id="menu-btn" class="text-green-900 focus:outline-none">
+          <button
+            id="menu-btn"
+            class="text-green-900 focus:outline-none"
+            aria-label="Toggle navigation"
+            aria-controls="mobile-menu"
+            aria-expanded="false"
+          >
             <i class="fas fa-bars text-2xl"></i>
           </button>
         </div>
@@ -1155,6 +1161,8 @@
       const mobileMenu = document.getElementById("mobile-menu");
 
       menuBtn.addEventListener("click", () => {
+        const expanded = menuBtn.getAttribute("aria-expanded") === "true";
+        menuBtn.setAttribute("aria-expanded", String(!expanded));
         mobileMenu.classList.toggle("hidden");
       });
 
@@ -1175,6 +1183,7 @@
             // Close mobile menu if open
             if (!mobileMenu.classList.contains("hidden")) {
               mobileMenu.classList.add("hidden");
+              menuBtn.setAttribute("aria-expanded", "false");
             }
           }
         });


### PR DESCRIPTION
## Summary
- Improve mobile menu button accessibility with ARIA attributes and controls association.
- Update JavaScript to toggle `aria-expanded` and reset it when closing the menu.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d3ecfc04832e924bf60f324a660f