### PR TITLE
feat: add primary button class

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,8 @@
         </p>
         <a
           href="#contact"
-          class="inline-block bg-green-700 hover:bg-green-800 text-white font-bold py-3 px-8 rounded-lg transition duration-300 transform hover:scale-105"
+          class="btn-primary"
+          role="button"
         >
           Request a Free Survey
         </a>
@@ -1033,7 +1034,7 @@
                 </div>
                 <button
                   type="submit"
-                  class="w-full bg-green-700 hover:bg-green-800 text-white font-bold py-3 px-4 rounded-lg transition duration-300"
+                  class="btn-primary w-full"
                 >
                   Send Request
                 </button>
@@ -1138,7 +1139,8 @@
             <div class="mt-6">
               <a
                 href="#contact"
-                class="inline-block bg-green-700 hover:bg-green-800 text-white font-bold py-2 px-6 rounded-lg transition duration-300"
+                class="btn-primary"
+                role="button"
               >
                 Request Survey
               </a>

--- a/style.css
+++ b/style.css
@@ -96,3 +96,28 @@ iframe {
   line-height: 1.6;
 }
 
+/* Primary button styles */
+.btn-primary {
+  display: inline-block;
+  padding: clamp(0.5rem, 1.5vw, 0.75rem) clamp(1rem, 4vw, 2rem);
+  border-radius: 0.5rem;
+  background-color: #15803d; /* Tailwind green-700 */
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.btn-primary:hover {
+  background-color: #166534; /* Tailwind green-800 */
+  transform: scale(1.05);
+}
+
+.btn-primary:focus {
+  outline: 3px solid #bbf7d0; /* accessible focus ring */
+  outline-offset: 2px;
+}
+


### PR DESCRIPTION
## Summary
- style.css: introduce reusable `.btn-primary` button style with responsive padding, hover state, and focus outline
- index.html: apply new `btn-primary` class to hero, contact form, and footer call-to-action links

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72460ee58832e92bc36e23ebd0808