### PR TITLE
feat: introduce section-grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,8 +548,8 @@
     <!-- About Section -->
     <section id="about" class="py-16">
       <div class="section-card">
-        <div class="flex flex-col lg:flex-row items-center">
-          <div class="lg:w-1/2 mb-8 lg:mb-0 lg:pr-8">
+        <div class="section-grid items-center">
+          <div>
             <h2
               class="title-font section-heading font-bold text-green-800 mb-6"
             >
@@ -578,7 +578,7 @@
               </p>
             </div>
           </div>
-          <div class="lg:w-1/2">
+          <div>
             <div class="bg-white p-2 rounded-lg shadow-md">
               <img
                 src="Images/expert_at_work_lawn.png"
@@ -928,8 +928,8 @@
     <!-- Contact Section -->
     <section id="contact" class="py-16">
       <div class="section-card">
-        <div class="flex flex-col lg:flex-row">
-          <div class="lg:w-1/2 mb-8 lg:mb-0 lg:pr-8">
+        <div class="section-grid">
+          <div>
             <h2 class="title-font section-heading font-bold mb-6">
               Get In Touch
             </h2>
@@ -984,7 +984,7 @@
             </div>
           </div>
 
-          <div class="lg:w-1/2">
+          <div>
             <div class="bg-white p-6 rounded-lg shadow-lg">
               <h3 class="title-font text-2xl font-bold text-green-800 mb-6">
                 Request a Free Survey

--- a/style.css
+++ b/style.css
@@ -96,6 +96,23 @@ iframe {
   padding: clamp(1.25rem, 5vw, 4rem);
 }
 
+.section-grid {
+  display: grid;
+  gap: clamp(1rem, 2vw, 2.5rem);
+}
+
+@media (min-width: 1280px) {
+  .section-grid {
+    grid-template-columns: 3fr 2fr;
+  }
+}
+
+@media (min-width: 900px) and (max-width: 1279px) {
+  .section-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
 .section-heading {
   font-size: clamp(1.875rem, 5vw, 2.25rem);
   line-height: 1.2;


### PR DESCRIPTION
## Summary
- add reusable `.section-grid` utility for responsive two-column layouts
- apply grid to About and Contact sections, removing old flex-based markup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72ab54580832ebef09fe1c2f34bac