### PR TITLE
Scope smooth-scroll handlers to mobile menu links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1190,13 +1190,29 @@
         });
       });
 
-      // Smooth scrolling for anchor links
-      document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+      // Smooth scrolling for mobile menu links
+      mobileMenu.querySelectorAll("a").forEach((anchor) => {
         anchor.addEventListener("click", function (e) {
+          const targetId = this.getAttribute("href");
+          if (!targetId || targetId === "#") return;
           e.preventDefault();
 
+          const targetElement = document.querySelector(targetId);
+          if (targetElement) {
+            targetElement.scrollIntoView({
+              behavior: "smooth",
+            });
+          }
+        });
+      });
+
+      // Smooth scrolling for other in-page anchor links
+      document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+        if (mobileMenu.contains(anchor)) return;
+        anchor.addEventListener("click", function (e) {
           const targetId = this.getAttribute("href");
-          if (targetId === "#") return;
+          if (!targetId || targetId === "#") return;
+          e.preventDefault();
 
           const targetElement = document.querySelector(targetId);
           if (targetElement) {


### PR DESCRIPTION
## Summary
- Limit smooth-scroll binding to mobile menu anchors
- Add separate handler for other in-page links to keep desktop anchors unaffected

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Ridge-Burrow/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a73198fb04832ea820f6db028dac5d