### PR TITLE
Fix mobile navigation menu toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,11 @@
         </div>
       </div>
       <!-- Mobile menu -->
-      <div id="mobile-menu" class="md:hidden bg-white px-4 pb-4" aria-hidden="true">
+      <div
+        id="mobile-menu"
+        class="md:hidden bg-white px-4 pb-4 hidden"
+        aria-hidden="true"
+      >
         <a
           href="#services"
           class="block py-2 text-green-900 hover:text-green-700"
@@ -1171,19 +1175,19 @@
       const mobileMenu = document.getElementById("mobile-menu");
 
       menuBtn.addEventListener("click", () => {
-        const isOpen = mobileMenu.classList.toggle("open");
+        const isHidden = mobileMenu.classList.toggle("hidden");
+        const isOpen = !isHidden;
+        mobileMenu.classList.toggle("open", isOpen);
         document.body.classList.toggle("menu-open", isOpen);
         menuBtn.setAttribute("aria-expanded", String(isOpen));
-        mobileMenu.setAttribute(
-          "aria-hidden",
-          isOpen ? "false" : "true"
-        );
+        mobileMenu.setAttribute("aria-hidden", String(!isOpen));
       });
 
       // Close mobile menu when a link is clicked
       mobileMenu.querySelectorAll("a").forEach((link) => {
         link.addEventListener("click", () => {
           mobileMenu.classList.remove("open");
+          mobileMenu.classList.add("hidden");
           document.body.classList.remove("menu-open");
           menuBtn.setAttribute("aria-expanded", "false");
           mobileMenu.setAttribute("aria-hidden", "true");


### PR DESCRIPTION
## Summary
- Ensure mobile navigation menu becomes visible when hamburger button is tapped by toggling `hidden`/`open` classes and updating ARIA attributes.

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a736ab85c0832e8f353de05e9ddeea