### PR TITLE
Add name attributes to contact form inputs for backend submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -1000,11 +1000,12 @@
                     class="block text-stone-700 font-medium mb-2"
                     >Your Name</label
                   >
-                  <input
-                    type="text"
-                    id="name"
-                    class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-600"
-                  />
+                    <input
+                      type="text"
+                      id="name"
+                      name="name"
+                      class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-600"
+                    />
                 </div>
                 <div class="mb-4">
                   <label
@@ -1012,11 +1013,12 @@
                     class="block text-stone-700 font-medium mb-2"
                     >Phone Number</label
                   >
-                  <input
-                    type="tel"
-                    id="phone"
-                    class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-600"
-                  />
+                    <input
+                      type="tel"
+                      id="phone"
+                      name="phone"
+                      class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-600"
+                    />
                 </div>
                 <div class="mb-4">
                   <label
@@ -1024,11 +1026,12 @@
                     class="block text-stone-700 font-medium mb-2"
                     >Postcode</label
                   >
-                  <input
-                    type="text"
-                    id="postcode"
-                    class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-600"
-                  />
+                    <input
+                      type="text"
+                      id="postcode"
+                      name="postcode"
+                      class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-600"
+                    />
                 </div>
                 <div class="mb-6">
                   <label
@@ -1036,11 +1039,12 @@
                     class="block text-stone-700 font-medium mb-2"
                     >Your Pest Problem</label
                   >
-                  <textarea
-                    id="message"
-                    rows="4"
-                    class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-600"
-                  ></textarea>
+                    <textarea
+                      id="message"
+                      name="message"
+                      rows="4"
+                      class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-600"
+                    ></textarea>
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
## Summary
- add explicit `name` attributes to contact form fields so backend receives `name`, `phone`, `postcode`, and `message`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab307d5904832e85b3c7c939ec0574