### PR TITLE
Restore contact form endpoint with autoresponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,9 @@ A static marketing site for Ridge & Burrow pest control in Cheshire. The page us
 
 Open `index.html` in a browser to view the site.
 
-## Contact Form Setup
+## Contact Form
 
-The "Request a Free Survey" form submits to [Formspree](https://formspree.io).
-
-1. Replace the placeholder form ID (`yournewid`) in `index.html` with the ID from your Formspree dashboard.
-2. Optionally configure email forwarding or integrations in your Formspree account.
-3. Test by submitting the form on the site; Formspree will email submissions to the address you specify.
-
-No additional backend is required for basic email forwarding.
+The "Request a Free Survey" form posts to [FormSubmit](https://formsubmit.co) and
+sends submissions directly to `chadsuckley1@gmail.com`. The form includes an
+automatic reply so users receive confirmation after submitting. To change the
+recipient or autoresponse, update the `form` element in `index.html`.

--- a/index.html
+++ b/index.html
@@ -993,14 +993,62 @@
               <h3 class="title-font text-2xl font-bold text-green-800 mb-6">
                 Request a Free Survey
               </h3>
-              <a
-                href="mailto:info@ridgeandburrow.co.uk"
-                class="btn-primary w-full block text-center"
-                role="button"
-                aria-label="Contact us via email"
+              <form
+                action="https://formsubmit.co/chadsuckley1@gmail.com"
+                method="POST"
+                class="space-y-4"
               >
-                Contact us
-              </a>
+                <input
+                  type="hidden"
+                  name="_autoresponse"
+                  value="Thank you for contacting Ridge &amp; Burrow. We'll be in touch soon."
+                />
+                <div>
+                  <label
+                    for="name"
+                    class="block text-sm font-medium text-stone-700"
+                    >Name</label
+                  >
+                  <input
+                    type="text"
+                    id="name"
+                    name="name"
+                    required
+                    class="mt-1 w-full p-2 border border-stone-300 rounded"
+                  />
+                </div>
+                <div>
+                  <label
+                    for="email"
+                    class="block text-sm font-medium text-stone-700"
+                    >Email</label
+                  >
+                  <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    required
+                    class="mt-1 w-full p-2 border border-stone-300 rounded"
+                  />
+                </div>
+                <div>
+                  <label
+                    for="message"
+                    class="block text-sm font-medium text-stone-700"
+                    >Message</label
+                  >
+                  <textarea
+                    id="message"
+                    name="message"
+                    rows="4"
+                    required
+                    class="mt-1 w-full p-2 border border-stone-300 rounded"
+                  ></textarea>
+                </div>
+                <button type="submit" class="btn-primary w-full">
+                  Send Message
+                </button>
+              </form>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add contact form that posts to FormSubmit and emails chadsuckley1@gmail.com
- include autoresponse so visitors get confirmation after submitting
- document the form submission behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b1b822c8832e8ccb03011b246c40