### PR TITLE
Use CSS variable for hero background image

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,7 @@ body {
 }
 
 .hero-image {
+  --hero-image-url: url("Images/ridge_burrow_banner.png");
   position: relative;
   overflow: hidden;
   background-color: #a84719;
@@ -18,7 +19,7 @@ body {
       rgba(173, 75, 21, 0.56) 45%,
       rgba(213, 128, 61, 0.28) 100%
     ),
-    url("Images/ridge_burrow_banner.png");
+    var(--hero-image-url);
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;


### PR DESCRIPTION
### Motivation
- Make the hero background image source explicit and easier to override by centralizing it as a CSS custom property while ensuring it uses `Images/ridge_burrow_banner.png`.

### Description
- Updated the `.hero-image` block in `style.css` to define `--hero-image-url: url("Images/ridge_burrow_banner.png")` and replaced the direct `url(...)` usage with `var(--hero-image-url)` so the existing gradient and layout remain unchanged.

### Testing
- Served the site with `python -m http.server 4173` and ran a Playwright capture of the page to `artifacts/hero-update.png`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8198483e0832ea802a2e599eb71e3)